### PR TITLE
Fix loading of protocol module for Electron 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
 // Load dependencies
 var app = require('electron').app,
+    protocol = require('electron').protocol,
     ejs = require('ejs'),
     mime = require('mime')
     fs = require('fs'),
     url = require('url')
 
 // Private variables
-var protocol, // will be set to the protocol module, which is only available inside `app.on('ready', ...`
-    userOpts = {}
-
+var userOpts = {}
 
 // Helper functions
 var compileEjs = function(contentBuffer) {
     var contentString = contentBuffer.toString(),
         compiledEjs = ejs.render(contentString, userOpts)
-    
+
     return new Buffer(compiledEjs)
 }
 
@@ -24,19 +23,19 @@ var protocolListener = function(request, callback) {
             fileContents = fs.readFileSync(fileName),
             extension = fileName.split('.').pop(),
             mimeType = mime.lookup(extension)
-        
+
         if (extension === 'ejs') {
             userOpts.filename = fileName
             userOpts.ejse = this
             fileContents = compileEjs(fileContents)
             mimeType = 'text/html'
         }
-        
+
         return callback({
             data: fileContents,
             mimeType: mimeType
         })
-        
+
     } catch(exception) {
         return callback(-6) // NET_ERROR(FILE_NOT_FOUND, -6)
     }
@@ -47,29 +46,28 @@ var protocolListener = function(request, callback) {
 var EJSE = function() {
     var self = this
     app.on('ready', function() {
-        protocol = require('protocol')
         self.listen()
     })
 }
 EJSE.prototype = {
-    
+
     // Start intercepting requests, looking for '.ejs' files.
     listen: function() {
         if (!protocol) return this
         protocol.interceptBufferProtocol('file', protocolListener.bind(this))
         return this
     },
-    
+
     // Set the options to be passed in to `ejs.render()`.
     setOptions: function(optsIn) {
         userOpts = optsIn || {}
         return this
     },
-    
+
     // Stop intercepting requests, restoring the original `file://` protocol handler.
     stopListening: function() {
         if (!protocol) return this
-        
+
         protocol.uninterceptProtocol('file')
         return this
     }


### PR DESCRIPTION
Electron 1.0 deprecated the old way of loading built-in modules, which
causes ejs-electron to crash when attempting to load the protocol module.
Fix by loading protocol from the single electron module.

See http://electron.atom.io/blog/2015/11/17/electron-api-changes