### PR TITLE
Fixed mime.lookup() not a function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function protocolListener(request, callback) {
 		let pathname = parsePathname(request.url)
         let fileContents = fs.readFileSync(pathname)
         let extension = path.extname(pathname)
-        let mimeType = mime.lookup(extension)
+        let mimeType = mime.getType(extension)
 
         if (extension === '.ejs') {
             fileContents = compileEjs(pathname, fileContents)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-electron",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-electron",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A lightweight module for ejs templating in an electronJS app.",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
PR resolves the issue mentioned in https://github.com/bowheart/ejs-electron/issues/11, see that issue for more details.