### PR TITLE
Adds option to retrieve entire data set

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ const ejse = require('ejs-electron')
 Get/set the data (context) that will be passed to `ejs.render()`.
 
 Overloads:
+- `ejse.data()` -- Retrieve the current data set.
 - `ejse.data('key')` -- Retrieve the value of `'key'` in the current data set.
 - `ejse.data('key', 'val')` -- Set `'key'` to `'val' `in the current data set.
 - `ejse.data({key: 'val'})` -- Replace the current data set with a new one containing `{key: 'val'}`

--- a/index.js
+++ b/index.js
@@ -135,6 +135,12 @@ function protocolListener(request, callback) {
 
 
 function updateState(field, context, key, val) {
+  if (typeof key === 'undefined' && typeof val === 'undefined') {
+    let data = state[field];
+    delete data.ejse;
+    return data
+  }
+
 	if (typeof key === 'string') {
 		if (typeof val === 'undefined') return state[field][key]
 		state[field][key] = val


### PR DESCRIPTION
Calling `ejse.data()` without args will return entire dataset. 